### PR TITLE
Feature: Custom texture size

### DIFF
--- a/Editor/TexturePackerWindow.cs
+++ b/Editor/TexturePackerWindow.cs
@@ -117,9 +117,7 @@ namespace TexPacker
             {
                 if (_texturePacker.texInputs.Count > 0)
                 {
-                    Texture firstInputTex = _texturePacker.texInputs[0].texture;
-                    _texturePacker.texSize.x = firstInputTex.width;
-                    _texturePacker.texSize.y = firstInputTex.height;
+                    SetTexSizeFromInput(_texturePacker.texInputs[0]);
                 }
 
                 _texturePacker.texSize.x = Mathf.Abs(EditorGUILayout.IntField("> Texture width:", _texturePacker.texSize.x));

--- a/Editor/TexturePackerWindow.cs
+++ b/Editor/TexturePackerWindow.cs
@@ -27,6 +27,7 @@ namespace TexPacker
         private TexturePreview _preview;
 
         private bool _useCustomTexSize = false;
+        private bool _overrideDefaultTextSize = true;
 
         [MenuItem("Window/Channel Packer")]
         static void Open()
@@ -115,10 +116,11 @@ namespace TexPacker
 
             if (_useCustomTexSize)
             {
-                if (_texturePacker.texInputs.Count > 0)
+                if (_overrideDefaultTextSize && _texturePacker.texInputs.Count == 1)
                 {
                     SetTexSizeFromInput(_texturePacker.texInputs[0]);
                 }
+                _overrideDefaultTextSize = false;
 
                 _texturePacker.texSize.x = Mathf.Abs(EditorGUILayout.IntField("> Texture width:", _texturePacker.texSize.x));
                 _texturePacker.texSize.y = Mathf.Abs(EditorGUILayout.IntField("> Texture height:", _texturePacker.texSize.y));
@@ -143,6 +145,7 @@ namespace TexPacker
             else
             {
                 _texturePacker.texSize = Vector2Int.one * EditorGUILayout.IntPopup("> Resolution:", _texturePacker.resolution, _textureResolutionsNames.ToArray(), _textureResolutions.ToArray());
+                _overrideDefaultTextSize = true;
             }
 
             GUILayout.EndVertical();

--- a/Editor/TexturePackerWindow.cs
+++ b/Editor/TexturePackerWindow.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using UnityEditor;
@@ -40,7 +40,7 @@ namespace TexPacker
             minSize = _windowSize;
             titleContent = new GUIContent(_windowTitle);
 
-            for(int i = _textureSupportedResolutionMin; i <= _textureSupportedResolutionMax; i *= 2)
+            for (int i = _textureSupportedResolutionMin; i <= _textureSupportedResolutionMax; i *= 2)
             {
                 _textureResolutions.Add(i);
                 _textureResolutionsNames.Add(i.ToString());
@@ -55,12 +55,17 @@ namespace TexPacker
             if (_items.Count == 0)
                 return;
 
-            var toDeleteItems = _items.Where(x => x.toDelete==true).ToList();
+            var toDeleteItems = _items.Where(x => x.toDelete == true).ToList();
             foreach (var item in toDeleteItems)
             {
                 _texturePacker.Remove(item.input);
                 _items.Remove(item);
             }
+        }
+
+        private void SetTexSizeFromInput(TextureInput input)
+        {
+            _texturePacker.texSize = input.texture == null ? Vector2Int.zero : new Vector2Int(input.texture.width, input.texture.height);
         }
 
         private void OnGUI()
@@ -110,9 +115,26 @@ namespace TexPacker
 
             if (_useCustomTexSize)
             {
-                int width = EditorGUILayout.IntField("> Texture width:", _texturePacker.texSize.x);
-                int height = EditorGUILayout.IntField("> Texture height:", _texturePacker.texSize.y);
+                int width = Mathf.Abs(EditorGUILayout.IntField("> Texture width:", _texturePacker.texSize.x));
+                int height = Mathf.Abs(EditorGUILayout.IntField("> Texture height:", _texturePacker.texSize.y));
                 _texturePacker.texSize = new Vector2Int(width, height);
+
+                if (_texturePacker.texInputs.Count > 0)
+                {
+                    EditorGUILayout.Separator();
+                    if (GUILayout.Button("Use size from input"))
+                    {
+                        var menu = new GenericMenu();
+                        for (int i = 0; i < _texturePacker.texInputs.Count; i++)
+                        {
+                            TextureInput input = _texturePacker.texInputs[i];
+                            menu.AddItem(new GUIContent($"Input {i + 1}"), on: false, () => SetTexSizeFromInput(input));
+                        }
+
+                        var dropdownPos = new Rect(Event.current.mousePosition, size: Vector2.zero);
+                        menu.DropDown(dropdownPos);
+                    }
+                }
             }
             else
             {
@@ -124,10 +146,10 @@ namespace TexPacker
             if (GUILayout.Button("Generate Texture", TexturePackerStyles.Button))
             {
                 string defaultPath = Application.dataPath;
-                if(_texturePacker.texInputs.Count > 0 && _texturePacker.texInputs[0].texture != null)
+                if (_texturePacker.texInputs.Count > 0 && _texturePacker.texInputs[0].texture != null)
                 {
                     string path = AssetDatabase.GetAssetPath(_texturePacker.texInputs[0].texture);
-                    if(path != null && !string.IsNullOrEmpty(path))
+                    if (path != null && !string.IsNullOrEmpty(path))
                     {
                         path = Path.Combine(Application.dataPath, "..", path);
                         defaultPath = Path.GetDirectoryName(path);
@@ -138,9 +160,9 @@ namespace TexPacker
                 {
                     Texture2D output = _texturePacker.Create();
 
-                    if(_textureFormat == TextureFormat.JPG)
+                    if (_textureFormat == TextureFormat.JPG)
                         File.WriteAllBytes(savePath, output.EncodeToJPG());
-                    else if(_textureFormat == TextureFormat.PNG)
+                    else if (_textureFormat == TextureFormat.PNG)
                         File.WriteAllBytes(savePath, output.EncodeToPNG());
                     else
                         File.WriteAllBytes(savePath, output.EncodeToEXR());

--- a/Editor/TexturePackerWindow.cs
+++ b/Editor/TexturePackerWindow.cs
@@ -27,7 +27,7 @@ namespace TexPacker
         private TexturePreview _preview;
 
         private bool _useCustomTexSize = false;
-        private bool _overrideDefaultTextSize = true;
+        private bool _overrideDefaultTexSize = true;
 
         [MenuItem("Window/Channel Packer")]
         static void Open()
@@ -116,11 +116,11 @@ namespace TexPacker
 
             if (_useCustomTexSize)
             {
-                if (_overrideDefaultTextSize && _texturePacker.texInputs.Count == 1)
+                if (_overrideDefaultTexSize && _texturePacker.texInputs.Count == 1)
                 {
                     SetTexSizeFromInput(_texturePacker.texInputs[0]);
                 }
-                _overrideDefaultTextSize = false;
+                _overrideDefaultTexSize = false;
 
                 _texturePacker.texSize.x = Mathf.Abs(EditorGUILayout.IntField("> Texture width:", _texturePacker.texSize.x));
                 _texturePacker.texSize.y = Mathf.Abs(EditorGUILayout.IntField("> Texture height:", _texturePacker.texSize.y));
@@ -145,7 +145,7 @@ namespace TexPacker
             else
             {
                 _texturePacker.texSize = Vector2Int.one * EditorGUILayout.IntPopup("> Resolution:", _texturePacker.resolution, _textureResolutionsNames.ToArray(), _textureResolutions.ToArray());
-                _overrideDefaultTextSize = true;
+                _overrideDefaultTexSize = true;
             }
 
             GUILayout.EndVertical();

--- a/Editor/TexturePackerWindow.cs
+++ b/Editor/TexturePackerWindow.cs
@@ -26,6 +26,8 @@ namespace TexPacker
         private List<TextureItem> _items = new List<TextureItem>();
         private TexturePreview _preview;
 
+        private bool _useCustomTexSize = false;
+
         [MenuItem("Window/Channel Packer")]
         static void Open()
         {
@@ -93,17 +95,30 @@ namespace TexPacker
             GUILayout.FlexibleSpace();
             EditorGUILayout.EndHorizontal();
 
-            int prevRes = _texturePacker.resolution;
+            Vector2Int prevTexSize = _texturePacker.texSize;
             _texturePacker.resolution = 128;
 
             _preview.Draw(_texturePacker);
 
-            _texturePacker.resolution = prevRes;
+            _texturePacker.texSize = prevTexSize;
 
             GUILayout.Label("Options", TexturePackerStyles.Heading);
             GUILayout.BeginVertical(TexturePackerStyles.Section);
             _textureFormat = (TextureFormat)EditorGUILayout.EnumPopup("> Format:", _textureFormat);
-            _texturePacker.resolution = EditorGUILayout.IntPopup("> Resolution:", _texturePacker.resolution, _textureResolutionsNames.ToArray(), _textureResolutions.ToArray());
+
+            _useCustomTexSize = EditorGUILayout.Toggle("> Custom texture size:", _useCustomTexSize);
+
+            if (_useCustomTexSize)
+            {
+                int width = EditorGUILayout.IntField("> Texture width:", _texturePacker.texSize.x);
+                int height = EditorGUILayout.IntField("> Texture height:", _texturePacker.texSize.y);
+                _texturePacker.texSize = new Vector2Int(width, height);
+            }
+            else
+            {
+                _texturePacker.texSize = Vector2Int.one * EditorGUILayout.IntPopup("> Resolution:", _texturePacker.resolution, _textureResolutionsNames.ToArray(), _textureResolutions.ToArray());
+            }
+
             GUILayout.EndVertical();
 
             if (GUILayout.Button("Generate Texture", TexturePackerStyles.Button))

--- a/Editor/TexturePackerWindow.cs
+++ b/Editor/TexturePackerWindow.cs
@@ -115,9 +115,15 @@ namespace TexPacker
 
             if (_useCustomTexSize)
             {
-                int width = Mathf.Abs(EditorGUILayout.IntField("> Texture width:", _texturePacker.texSize.x));
-                int height = Mathf.Abs(EditorGUILayout.IntField("> Texture height:", _texturePacker.texSize.y));
-                _texturePacker.texSize = new Vector2Int(width, height);
+                if (_texturePacker.texInputs.Count > 0)
+                {
+                    Texture firstInputTex = _texturePacker.texInputs[0].texture;
+                    _texturePacker.texSize.x = firstInputTex.width;
+                    _texturePacker.texSize.y = firstInputTex.height;
+                }
+
+                _texturePacker.texSize.x = Mathf.Abs(EditorGUILayout.IntField("> Texture width:", _texturePacker.texSize.x));
+                _texturePacker.texSize.y = Mathf.Abs(EditorGUILayout.IntField("> Texture height:", _texturePacker.texSize.y));
 
                 if (_texturePacker.texInputs.Count > 0)
                 {

--- a/Editor/TexturePackerWindow.cs.meta
+++ b/Editor/TexturePackerWindow.cs.meta
@@ -1,13 +1,2 @@
 fileFormatVersion: 2
 guid: ccb4b81226a897345898c0c1e08e4f14
-timeCreated: 1518232730
-licenseType: Free
-MonoImporter:
-  externalObjects: {}
-  serializedVersion: 2
-  defaultReferences: []
-  executionOrder: 0
-  icon: {instanceID: 0}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Runtime/TexturePacker.cs
+++ b/Runtime/TexturePacker.cs
@@ -18,7 +18,8 @@ namespace TexPacker
         private int _resolution;
         public int resolution {
             get { return _resolution; }
-            set  {
+            set
+            {
                 _resolution = value;
                 texSize = Vector2Int.one * value;
             }

--- a/Runtime/TexturePacker.cs
+++ b/Runtime/TexturePacker.cs
@@ -13,7 +13,16 @@ namespace TexPacker
             get { return _texInputs; }
         }
 
-        public int resolution = 2048;
+        public Vector2Int texSize = new Vector2Int(2048, 2048);
+
+        private int _resolution;
+        public int resolution {
+            get { return _resolution; }
+            set  {
+                _resolution = value;
+                texSize = Vector2Int.one * value;
+            }
+        }
 
         public void Initialize()
         {
@@ -108,7 +117,7 @@ namespace TexPacker
                 ++idx;
             }
 
-            var texture = TextureUtility.GenerateTexture(resolution, resolution, _material);
+            var texture = TextureUtility.GenerateTexture(texSize.x, texSize.y, _material);
 
             return texture;
         }


### PR DESCRIPTION
### What I changed:
Issue #22 asked for support for packing non-square textures, so I added a toggle `Custom texture size` before the `Resolution` field which, when checked, replaces the `Resolution` field with a couple of options to set a custom texture width and height. As requested in the mentioned issue, the default custom size is the size of the first created input (if any) unless it's created before checking the `Custom texture size` toggle.

### Changes in the UI:
The mentioned toggle, located right on top of the `Resolution` field.
![image](https://github.com/user-attachments/assets/307c4346-9221-4428-84e6-0d99c6e24488)

All the new options to set a custom texture size, which appear when the toggle is checked. Note that the `Use size from input` button only appears when the user created at least one input.
![image](https://github.com/user-attachments/assets/11609577-fb00-497a-9e66-f99f5e99d6e0)

When clicking the `Use size from input` button, you get to choose from which of the inputs you added you want to import the texture size.

---

Closes #22 